### PR TITLE
added AreaLocation table, seed data, and added API and dropdown used …

### DIFF
--- a/backend/Controllers/AreaLocationController.cs
+++ b/backend/Controllers/AreaLocationController.cs
@@ -1,0 +1,33 @@
+using Microsoft.AspNetCore.Mvc;
+using WhaleSpotting.Models.Data;
+using WhaleSpotting.Models.Request;
+using WhaleSpotting.Models.Response;
+using WhaleSpotting.Services;
+
+namespace WhaleSpotting.Controllers;
+
+[ApiController]
+[Route("/arealocation")]
+public class AreaLocationController : Controller
+{
+    private readonly IAreaLocationService _service;
+
+    public AreaLocationController(IAreaLocationService service)
+    {
+        _service = service;
+    }
+
+    [HttpGet("")]
+    public IActionResult GetAllAreaLocation()
+    {
+        try
+        {
+            AreaLocationResponse areaLocationResponse = _service.GetAllAreaLocation();
+            return Ok(areaLocationResponse);
+        }
+        catch (Exception ex)
+        {
+            return BadRequest(ex.Message);
+        }
+    }
+}

--- a/backend/Migrations/20241008134246_AddAreaLocationTable.Designer.cs
+++ b/backend/Migrations/20241008134246_AddAreaLocationTable.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using WhaleSpotting;
@@ -11,9 +12,11 @@ using WhaleSpotting;
 namespace WhaleSpotting.Migrations
 {
     [DbContext(typeof(WhaleSpottingContext))]
-    partial class WhaleSpottingContextModelSnapshot : ModelSnapshot
+    [Migration("20241008134246_AddAreaLocationTable")]
+    partial class AddAreaLocationTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/Migrations/20241008134246_AddAreaLocationTable.cs
+++ b/backend/Migrations/20241008134246_AddAreaLocationTable.cs
@@ -1,0 +1,52 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace WhaleSpotting.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAreaLocationTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "AreaLocation",
+                columns: table => new
+                {
+                    Id = table
+                        .Column<int>(type: "integer", nullable: false)
+                        .Annotation(
+                            "Npgsql:ValueGenerationStrategy",
+                            NpgsqlValueGenerationStrategy.IdentityByDefaultColumn
+                        ),
+                    LocationName = table.Column<string>(type: "text", nullable: true),
+                    Latitude = table.Column<float>(type: "real", nullable: false),
+                    Longitude = table.Column<float>(type: "real", nullable: false),
+                    Radius = table.Column<float>(type: "real", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AreaLocation", x => x.Id);
+                }
+            );
+
+            // migrationBuilder.AddForeignKey(
+            //     name: "FK_Sightings_AspNetUsers_UserId",
+            //     table: "Sightings",
+            //     column: "UserId",
+            //     principalTable: "AspNetUsers",
+            //     principalColumn: "Id",
+            //     onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(name: "FK_Sightings_AspNetUsers_UserId", table: "Sightings");
+
+            migrationBuilder.DropTable(name: "AreaLocation");
+        }
+    }
+}

--- a/backend/Migrations/20241009110128_amendAreaLocationTable.Designer.cs
+++ b/backend/Migrations/20241009110128_amendAreaLocationTable.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using WhaleSpotting;
@@ -11,9 +12,11 @@ using WhaleSpotting;
 namespace WhaleSpotting.Migrations
 {
     [DbContext(typeof(WhaleSpottingContext))]
-    partial class WhaleSpottingContextModelSnapshot : ModelSnapshot
+    [Migration("20241009110128_amendAreaLocationTable")]
+    partial class amendAreaLocationTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/Migrations/20241009110128_amendAreaLocationTable.cs
+++ b/backend/Migrations/20241009110128_amendAreaLocationTable.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace WhaleSpotting.Migrations
+{
+    /// <inheritdoc />
+    public partial class amendAreaLocationTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "LocationName",
+                table: "AreaLocation",
+                type: "text",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "text",
+                oldNullable: true
+            );
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "LocationName",
+                table: "AreaLocation",
+                type: "text",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text"
+            );
+        }
+    }
+}

--- a/backend/Models/Data/AreaLocation.cs
+++ b/backend/Models/Data/AreaLocation.cs
@@ -9,7 +9,7 @@ public class AreaLocation
 {
     [Key]
     public int Id { get; set; }
-    public string? LocationName { get; set; }
+    public string LocationName { get; set; }
     public float Latitude { get; set; }
     public float Longitude { get; set; }
     public float Radius { get; set; }

--- a/backend/Models/Data/AreaLocation.cs
+++ b/backend/Models/Data/AreaLocation.cs
@@ -1,0 +1,16 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+
+namespace WhaleSpotting.Models.Data;
+
+public class AreaLocation
+{
+    [Key]
+    public int Id { get; set; }
+    public string? LocationName { get; set; }
+    public float Latitude { get; set; }
+    public float Longitude { get; set; }
+    public float Radius { get; set; }
+}

--- a/backend/Models/Response/AreaLocationResponse.cs
+++ b/backend/Models/Response/AreaLocationResponse.cs
@@ -1,0 +1,8 @@
+using WhaleSpotting.Models.Data;
+
+namespace WhaleSpotting.Models.Response;
+
+public class AreaLocationResponse
+{
+    public List<AreaLocation>? ListOfAreaLocation { get; set; }
+}

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -46,6 +46,9 @@ public class Program
         builder.Services.AddTransient<SeedSpecies>();
         builder.Services.AddTransient<IUserService, UserService>();
 
+        builder.Services.AddTransient<SeedAreaLocation>();
+        builder.Services.AddTransient<IAreaLocationService, AreaLocationService>();
+
         builder.Services.AddTransient<SeedSightings>();
         builder.Services.AddTransient<ISpeciesService, SpeciesService>();
 
@@ -106,6 +109,8 @@ public class Program
         {
             var speciesSeeder = scope.ServiceProvider.GetService<SeedSpecies>();
             speciesSeeder.Seed();
+            var areaLocationSeeder = scope.ServiceProvider.GetService<SeedAreaLocation>();
+            areaLocationSeeder.AreaLocationSeed();
         }
 
         if (app.Environment.IsDevelopment())

--- a/backend/SeedData/SeedAreaLocation.cs
+++ b/backend/SeedData/SeedAreaLocation.cs
@@ -1,0 +1,53 @@
+using Microsoft.EntityFrameworkCore;
+using WhaleSpotting.Migrations;
+using WhaleSpotting.Models.Data;
+
+namespace WhaleSpotting.SeedData
+{
+    public class SeedAreaLocation
+    {
+        private readonly WhaleSpottingContext _context;
+
+        public SeedAreaLocation(WhaleSpottingContext context)
+        {
+            _context = context;
+        }
+
+        private readonly IList<AreaLocation> DataAreaLocation = new List<AreaLocation>
+        {
+            new AreaLocation()
+            {
+                Id = 1,
+                LocationName = "English Channel",
+                Latitude = 48.764F,
+                Longitude = -4.935F,
+                Radius = 25.3f
+            },
+            new AreaLocation()
+            {
+                Id = 2,
+                LocationName = "Indian Ocean",
+                Latitude = -20.0F,
+                Longitude = 80.0F,
+                Radius = 1000.3f
+            },
+            new AreaLocation()
+            {
+                Id = 3,
+                LocationName = "Pacific Ocean",
+                Latitude = 0.0F,
+                Longitude = 160.0F,
+                Radius = 500.3f
+            },
+        };
+
+        public void AreaLocationSeed()
+        {
+            if (!_context.AreaLocation.Any())
+            {
+                _context.AreaLocation.AddRange(DataAreaLocation);
+                _context.SaveChanges();
+            }
+        }
+    }
+}

--- a/backend/Services/AreaLocationService.cs
+++ b/backend/Services/AreaLocationService.cs
@@ -1,0 +1,29 @@
+using WhaleSpotting.Models.Data;
+using WhaleSpotting.Models.Request;
+using WhaleSpotting.Models.Response;
+
+namespace WhaleSpotting.Services;
+
+public interface IAreaLocationService
+{
+    public AreaLocationResponse GetAllAreaLocation();
+}
+
+public class AreaLocationService : IAreaLocationService
+{
+    private readonly WhaleSpottingContext _context;
+
+    public AreaLocationService(WhaleSpottingContext context)
+    {
+        _context = context;
+    }
+
+    public AreaLocationResponse GetAllAreaLocation()
+    {
+        AreaLocationResponse areaLocationResponse = new AreaLocationResponse()
+        {
+            ListOfAreaLocation = _context.AreaLocation.ToList()
+        };
+        return areaLocationResponse;
+    }
+}

--- a/backend/WhaleSpottingContext.cs
+++ b/backend/WhaleSpottingContext.cs
@@ -9,8 +9,8 @@ public class WhaleSpottingContext(DbContextOptions<WhaleSpottingContext> options
     : IdentityDbContext<User, Role, int>(options)
 {
     public DbSet<Sighting> Sightings { get; set; }
-
     public DbSet<Species> Species { get; set; }
+    public DbSet<AreaLocation> AreaLocation { get; set; }
 
     protected override void OnModelCreating(ModelBuilder builder)
     {

--- a/frontend/src/Components/AreaLocationDropDown/AreaLocationDropDown.tsx
+++ b/frontend/src/Components/AreaLocationDropDown/AreaLocationDropDown.tsx
@@ -1,0 +1,53 @@
+import { useState } from "react"
+
+interface AreaLocationType {
+  areaLocationId: number
+  locationName: string
+  latitude: number
+  longitude: number
+  radius: number
+}
+
+export function AreaLocationDropdown({
+  getLatFromDropdown,
+  getLongFromDropdown,
+}: {
+  getLatFromDropdown(latFromDropdown: number): void
+  getLongFromDropdown(longFromDropDown: number): void
+}) {
+  const [areaLocation, setAreaLocation] = useState<AreaLocationType[]>([])
+
+  if (areaLocation.length === 0) {
+    fetch("http://localhost:5280/arealocation", {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    })
+      .then((response) => response.json())
+      .then((data) => {
+        setAreaLocation(data.listOfAreaLocation)
+      })
+  }
+
+  if (!areaLocation) {
+    return <div>Loading...</div>
+  } else {
+    return (
+      <select
+        id="arealocation"
+        className="form-control"
+        onChange={(event) => {
+          getLatFromDropdown(areaLocation[event.target.selectedIndex].latitude)
+          getLongFromDropdown(areaLocation[event.target.selectedIndex].longitude)
+        }}
+      >
+        {areaLocation.map((option) => (
+          <option value={option.areaLocationId}>
+            {option.locationName} (Lat: {option.latitude} Long: {option.longitude} Radius: {option.radius})
+          </option>
+        ))}
+      </select>
+    )
+  }
+}

--- a/frontend/src/api/backendClient.ts
+++ b/frontend/src/api/backendClient.ts
@@ -101,6 +101,15 @@ export const getSpecies = async () => {
   })
 }
 
+export const getAreaLocation = async () => {
+  return await fetch(`http://localhost:5280/arealocation`, {
+    method: "get",
+    headers: {
+      "Content-Type": "application/json",
+    },
+  })
+}
+
 export async function fetchUserProfile(header: string): Promise<User> {
   const response = await fetch(`http://localhost:5280/users/profile`, {
     headers: {

--- a/frontend/src/pages/AddSighting/AddSighting.tsx
+++ b/frontend/src/pages/AddSighting/AddSighting.tsx
@@ -93,7 +93,7 @@ export function AddSighting(): JSX.Element {
           </div>
           <div className="form-group row justify-content-center pb-4">
             <label htmlFor="areaLocation" className="col-lg-3 col-sm-2 col-form-label">
-              Get Lat & Long from AreaLocation:
+              Get Lat & Long from Area/Location:
             </label>
             <div className="col-lg-7 col-sm-3">
               <AreaLocationDropdown getLatFromDropdown={getLatFromDropdown} getLongFromDropdown={getLongFromDropdown} />

--- a/frontend/src/pages/AddSighting/AddSighting.tsx
+++ b/frontend/src/pages/AddSighting/AddSighting.tsx
@@ -10,6 +10,7 @@ import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs"
 import { DateTimePicker } from "@mui/x-date-pickers"
 import dayjs, { Dayjs } from "dayjs"
 import "dayjs/locale/en-gb"
+import { AreaLocationDropdown } from "../../Components/AreaLocationDropDown/AreaLocationDropDown"
 
 export function AddSighting(): JSX.Element {
   const loginContext = useContext(LoginContext)
@@ -52,6 +53,14 @@ export function AddSighting(): JSX.Element {
     setSpeciesId(speciesIdFromDropdown)
   }
 
+  function getLatFromDropdown(latFromDropdown: number) {
+    setLatitude(String(latFromDropdown))
+  }
+
+  function getLongFromDropdown(longFromDropDown: number) {
+    setLongitude(String(longFromDropDown))
+  }
+
   function getUserLocation() {
     if (navigator.geolocation) {
       navigator.geolocation.getCurrentPosition(
@@ -80,6 +89,14 @@ export function AddSighting(): JSX.Element {
             </label>
             <div className="col-lg-7 col-sm-3">
               <SpeciesDropdown getSpeciesIdFromDropdown={getSpeciesIdFromDropdown} />
+            </div>
+          </div>
+          <div className="form-group row justify-content-center pb-4">
+            <label htmlFor="areaLocation" className="col-lg-3 col-sm-2 col-form-label">
+              Get Lat & Long from AreaLocation:
+            </label>
+            <div className="col-lg-7 col-sm-3">
+              <AreaLocationDropdown getLatFromDropdown={getLatFromDropdown} getLongFromDropdown={getLongFromDropdown} />
             </div>
           </div>
           <div className="col-lg-7 col-sm-3">


### PR DESCRIPTION
1. Create table AreaLocation
2. Create seed data for this table
3. Populate seed data to the database
4. Create backend API to list all
5. Added this API to the backendClients.tsx
6. Added dropdown list to get latitude and longitude from AreaLocation dropdown list in the Add Sightings page

Tested via Swagger, and from front-end when adding a new sighting to default the lat & long from the arealocation selected from dropdown